### PR TITLE
Quiz with added test cases

### DIFF
--- a/src/main/java/Problem3/Book.java
+++ b/src/main/java/Problem3/Book.java
@@ -12,6 +12,12 @@ public abstract class Book implements StoreMediaOperations {
         this.author = author;
         this.id = UUID.randomUUID();
     }
+    public void setId(UUID id) {
+        this.id = id;
+    }
+    public UUID getId() {
+        return this.id;
+    }
 
     public Book(Book anotherBook) {
         this.id = anotherBook.id;
@@ -37,6 +43,7 @@ public abstract class Book implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
+
         return id.equals(theOtherBook.id) &&
                 author.equals(theOtherBook.author) &&
                 title.equals(theOtherBook.title);

--- a/src/main/java/Problem3/BookFiction.java
+++ b/src/main/java/Problem3/BookFiction.java
@@ -19,6 +19,7 @@ public class BookFiction extends Book {
 
     @Override
     public int getLateFeeInDollar() {
+
         return lateFeePerDayInDollar;
     }
 

--- a/src/main/java/Problem3/Movie.java
+++ b/src/main/java/Problem3/Movie.java
@@ -19,6 +19,14 @@ public abstract class Movie implements StoreMediaOperations {
         this.id = anotherMovie.id;
     }
 
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getId() {
+        return this.id;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
@@ -37,6 +45,7 @@ public abstract class Movie implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
+
         return id.equals(theOtherMovie.id) &&
                 rating.equals(theOtherMovie.rating) &&
                 title.equals(theOtherMovie.title);

--- a/src/test/java/Problem3Test.java
+++ b/src/test/java/Problem3Test.java
@@ -6,12 +6,18 @@ import static org.junit.Assert.*;
 public class Problem3Test {
     @Test
     public void catchTheBugInBook() {
-        // quiz
+        Book f = new BookFiction("t1", "au1", "g1");
+        Book br = new BookRomance("t1", "a1");
+        f.setId(br.getId());
+        assertTrue(f.equals(br));
     }
 
     @Test
     public void catchTheBugInMovie() {
-        // quiz
+        Movie m = new MovieAction("PG13", "au2");
+        Movie mc = new MovieComedy("r1", "t1");
+        m.setId(mc.getId());
+        assertTrue(m.equals(mc));
     }
 
     // DO NOT REMOVE OR CHANGE ANYTHING BELOW THIS!


### PR DESCRIPTION
 In the original code our equals method for Movies returns true if the author, rating, and id are the same. This however is not what we want because we are only looking for if the Movies objects share the same id. Our original tests passed because in all our tests we did not have situations in which the id of our objects is the same with different ratings and titles. The same can also be said for the equals method in Book. To force a fail tests for our additional tests but maintain the passes of the original tests, we needed to create tests in which the objects had different titles, ratings, authors but the same id's. To do so I created getter methods for Book and Movies. In our bug catching tester methods, I created different objects with different values and then used the id getter to make them have the same id. Using the original equal method our bug catchers fail because they will not meet the requirement of the code despite meeting our personal requirement of sharing id's. When we switch to the fixed code, we find that the previous still passes and our bug catching methods are also passing. In the fix the titles, authors, ratings no longer matter and as a result all our tests pass. 